### PR TITLE
mint options v1 -> v2

### DIFF
--- a/src/hooks/psyAmerican/useMintOptions.ts
+++ b/src/hooks/psyAmerican/useMintOptions.ts
@@ -205,7 +205,7 @@ export const useMintOptions = (): ((size: number) => Promise<boolean>) => {
         }
 
         const { ix, signers: _signers } =
-          await instructions.mintOptionInstruction(
+          await instructions.mintOptionV2Instruction(
             program,
             optionTokenDest,
             writerTokenDest,


### PR DESCRIPTION
This gets rid of that extra underlying being sent to the DAO when minting options